### PR TITLE
[ALS-4721] Add named dataset modal and button.

### DIFF
--- a/pic-sure-hpds-ui-extension-archetype/src/main/resources/archetype-resources/src/main/webapp/picsureui/overrides/genomic-filter-view.js
+++ b/pic-sure-hpds-ui-extension-archetype/src/main/resources/archetype-resources/src/main/webapp/picsureui/overrides/genomic-filter-view.js
@@ -1,0 +1,22 @@
+define([], function(){
+	return {
+        /*
+         * Override how the genomic filters are applied and the modal is closed.
+        */
+       applyGenomicFilters : undefined,
+
+        /*
+         * This methind is used to set up the tab order of elements in the genomic filter modal.
+         * If you change the html elements order or add new elements, you need to update this method.
+         */ 
+        createTabIndex: undefined,
+
+        /*
+         * This method is used to disable the apply button in the genomic filter modal.
+         * If you want to control when the user is allowed to apply the filter, you need to update this method.
+         * The default behavior is to require a Gene_with_variant and
+         * to disable the apply button if there is no filters selected.
+         */
+        updateDisabledButtons: undefined,
+	};
+});

--- a/pic-sure-hpds-ui-extension-archetype/src/main/resources/archetype-resources/src/main/webapp/picsureui/overrides/named-dataset.js
+++ b/pic-sure-hpds-ui-extension-archetype/src/main/resources/archetype-resources/src/main/webapp/picsureui/overrides/named-dataset.js
@@ -1,0 +1,16 @@
+define([
+], function() {
+    return {
+		/*
+		 * This is a function that if defined replaces the normal render function
+		 * from outputPanel.
+		 */
+		renderOverride : undefined,
+
+		/*
+		* This function validates and saves the data from the form to the 
+		* /picsure/dataset/named api endpount
+		*/
+		onSave: undefined,
+    };
+});

--- a/pic-sure-hpds-ui-extension-archetype/src/main/resources/archetype-resources/src/main/webapp/picsureui/overrides/ontology.js
+++ b/pic-sure-hpds-ui-extension-archetype/src/main/resources/archetype-resources/src/main/webapp/picsureui/overrides/ontology.js
@@ -1,6 +1,10 @@
 define([], function(){
 	return {
 		/*
+		 * The timeout for the info columns query
+		 */
+		infoColumnsTimeout : undefined,
+		/*
 		 * A function that takes a PUI that is already split on forward slash and returns
 		 * the category value for that PUI.
 		 */

--- a/pic-sure-hpds-ui-extension-archetype/src/main/resources/archetype-resources/src/main/webapp/picsureui/overrides/outputPanel.js
+++ b/pic-sure-hpds-ui-extension-archetype/src/main/resources/archetype-resources/src/main/webapp/picsureui/overrides/outputPanel.js
@@ -47,6 +47,11 @@ define(["jquery", "handlebars", "backbone", "common/config"], function($, HBS, B
 		 */
 		runQuery: undefined,
 
+		/*
+		 * A function add more functionality to the output panel render function. This function will be called after the default render function.
+		 */
+		renderExt: undefined,
+
 		variantExplorerStatus: config.VariantExplorerStatus.disabled
 	};
 });

--- a/pic-sure-hpds-ui-extension-archetype/src/main/resources/archetype-resources/src/main/webapp/picsureui/overrides/package-data-view.js
+++ b/pic-sure-hpds-ui-extension-archetype/src/main/resources/archetype-resources/src/main/webapp/picsureui/overrides/package-data-view.js
@@ -2,27 +2,33 @@ define([
 ], function() {
     return {
         /*
-		 * hook to allow overrides to customize the download data function
+		 * Hook to allow overrides to customize the download data function
 		 */
         downloadData: undefined,
         /*
-		 * hook to allow overrides to customize the prepare function
+		 * Hook to allow overrides to customize the prepare function
 		 */
         prepare: undefined,
         /*
-		 * hook to allow overrides to customize the queryAsync function
+		 * Hook to allow overrides to customize the queryAsync function
 		 */
         queryAsync: undefined,
         /*
-		 * hook to allow overrides to customize the querySync function
+		 * Hook to allow overrides to customize the querySync function
 		 */
         querySync: undefined,
         /*
-		 * hook to allow overrides to customize the updateEstimations function
+         * Hook to allow overrides to customize the queryChangedCallback function.
+         * This function is called when the user makes a change to the tree.
+         * The first parameter is a reference to the package view.
+        */
+        queryChangedCallback: undefined,
+        /*
+		 * Hook to allow overrides to customize the updateEstimations function
 		 */
         updateEstimations: undefined,
         /*
-		 * hook to allow overrides to customize the updateQuery function
+		 * Hook to allow overrides to customize the updateQuery function
 		 */
         updateQuery: undefined,
     };

--- a/pic-sure-hpds-ui/src/main/webapp/picsureui/output/named-dataset.hbs
+++ b/pic-sure-hpds-ui/src/main/webapp/picsureui/output/named-dataset.hbs
@@ -1,0 +1,19 @@
+<div id="named-dataset">
+    <section id="dataset-query-info">
+        <p>Fill out the following information to save your dataset ID for future use. To view and manage your dataset ID's, go to the "User Profile" tab.</p>
+        <div class="row"><div>Dataset ID Name:</div><div><input type="text" id="dataset-name" value="" /></div></div>
+        <div class="row">
+            <div>Dataset ID:</div>
+            <div>
+                <span id="dataset-id">{{queryUUID}}</span>
+                <button id='copy-queryid-btn' class='btn btn-default alternate'>Copy</button>
+            </div>
+        </div>
+        <div class="row"><div>Username:</div><div>{{username}}</div></div>
+    </section>
+    <div id="errors" class="alert alert-danger hidden center" role="alert"></div>
+    <section id="buttons" class="center block">
+        <a class="left btn btn-default" id="cancel-btn">Cancel</a>
+        <a class="right btn btn-default alternate" id="save-btn">Save Dataset ID</a>
+    </section>
+</div>

--- a/pic-sure-hpds-ui/src/main/webapp/picsureui/output/named-dataset.js
+++ b/pic-sure-hpds-ui/src/main/webapp/picsureui/output/named-dataset.js
@@ -1,0 +1,79 @@
+define([
+    'backbone',
+    'handlebars',
+    'underscore',
+    "common/modal",
+    'text!output/named-dataset.hbs',
+    'overrides/named-dataset'
+], function (BB, HBS, _, modal, view, overrides) {
+    return BB.View.extend({
+        initialize: function (opts) {
+            this.template = HBS.compile(view);
+            this.modalSettings = opts.modalSettings;
+            this.previousModal = opts.previousModal;
+            this.queryUUID = opts.queryUUID;
+            this.username = JSON.parse(sessionStorage.getItem("session") || "{}")?.username;
+        },
+        events: {
+            'click #cancel-btn': 'onClose',
+            'click #save-btn': 'onSave',
+            "click #copy-queryid-btn" : "copyQueryId",
+        },
+        modalReturn: function(){
+            if (!this.previousModal) return;
+            const { view, title, onClose, options } = this.previousModal;
+            modal.displayModal(view, title, onClose, options);
+        },
+        onClose: function() {
+            this.modalSettings.onClose();
+            this.modalReturn();
+        },
+        onError: function(text){
+            $('#errors').html(text);
+            $("#errors").removeClass('hidden');
+        },
+        onSave: function() {
+            if (overrides && overrides.onSave) {
+                overrides.onSave();
+                return;
+            }
+
+            const name = $("#dataset-name").val();
+            if(name === ""){
+                this.onError("Please input a Dataset ID Name value");
+                $("#dataset-name").addClass('error');
+                return;
+            }
+            
+            $("#dataset-name").removeClass('error');
+            $("#errors").addClass('hidden');
+
+            $.ajax({
+                url: window.location.origin + "/picsure/dataset/named",
+                type: 'POST',
+                headers: {"Authorization": "Bearer " + JSON.parse(sessionStorage.getItem("session")).token},
+                contentType: 'application/json',
+                data: JSON.stringify({
+                    "queryId": this.queryUUID,
+                    "name": name
+                }),
+                success: function(){
+                    this.modalSettings.onSuccess(name);
+                    this.modalReturn();
+                }.bind(this),
+                error: function(response, status, error){
+                    this.onError("An error happened during request.");
+                    console.log(error);
+                }.bind(this)
+            });
+        },
+        copyQueryId: function () {
+            navigator.clipboard.writeText($("#dataset-id").html());
+            document.getElementById('copy-queryid-btn').innerText = "Copied!";
+        },
+        render: function () {
+            this.$el.html(this.template(this));
+            overrides.renderOverride && overrides.renderOverride(this);
+        }
+    });
+});

--- a/pic-sure-hpds-ui/src/main/webapp/picsureui/output/outputPanel.js
+++ b/pic-sure-hpds-ui/src/main/webapp/picsureui/output/outputPanel.js
@@ -35,12 +35,16 @@ define(["jquery", "output/dataSelection", "text!output/outputPanel.hbs", "picSur
 			},
 			select: function(event){
 				if(this.model.get("queryRan")){
-					modal.displayModal(
-						new packageDataView({model: this.model, query: JSON.parse(JSON.stringify(this.model.baseQuery)), modal: modal}), 
-						"Select Data for Export", 
-						()=>{$('#select-btn').focus();}, 
-						{isHandleTabs: true}
-					);
+					const title = "Select Data for Export";
+					const onClose = () => { $('#select-btn').focus(); };
+					const options = { isHandleTabs: true, width: "70%" };
+					const modalView = new packageDataView.View({
+						modalSettings: { title, onClose, options },
+						model: this.model,
+						exportModel: new packageDataView.Model(),
+						query: JSON.parse(JSON.stringify(this.model.baseQuery)),
+					});
+					modal.displayModal(modalView, title, onClose, options);
 				}
 			},
 			queryRunning: function(){

--- a/pic-sure-hpds-ui/src/main/webapp/picsureui/output/package-data-view.hbs
+++ b/pic-sure-hpds-ui/src/main/webapp/picsureui/output/package-data-view.hbs
@@ -11,10 +11,22 @@
     </section>
     <section id="query-id-container">
         <div id="download-spinner"></div>
-        <div id="resource-id-display"></div>
-    </section>
-    <section id="buttons" class="results-div">
-        <a class="center btn btn-default" id="prepare-btn">{{#if queryButtonLabel}}{{queryButtonLabel}}{{else}}Export Data{{/if}}</a>
-        <a class="center btn btn-default hidden" download="data.csv" id="download-btn">Download</a>
+        <div id="resource-id-display" class="hidden">
+            <input id="queryid-span" type="text" value="" readonly />
+            <button id="copy-queryid-btn" class="btn btn-default">Copy Dataset Id</button> 
+            <span id="query-status"></span>
+        </div>
+        <div id="buttons">
+            <a class="center btn btn-default" id="prepare-btn">{{#if queryButtonLabel}}{{queryButtonLabel}}{{else}}Export Data{{/if}}</a>
+            <a class="center btn btn-default hidden" download="data.csv" id="download-btn">Download</a>
+            <div id="save-dataset" class="hidden">
+                {{#if datasetName}}
+                    <p class="center" id="dataset-saved"><span class="glyphicon glyphicon-ok"></span> Dataset saved as "{{datasetName}}".</p>
+                    <p>Please refer to the User Profile tab for details.</p>
+                {{else}}
+                    <a class="center btn btn-default alternate" id="save-dataset-btn">Save Dataset ID</a>
+                {{/if}}
+            </div>
+        </div>
     </section>
 </div>

--- a/pic-sure-hpds-ui/src/main/webapp/picsureui/output/package-data-view.hbs
+++ b/pic-sure-hpds-ui/src/main/webapp/picsureui/output/package-data-view.hbs
@@ -19,14 +19,11 @@
         <div id="buttons">
             <a class="center btn btn-default" id="prepare-btn">{{#if queryButtonLabel}}{{queryButtonLabel}}{{else}}Export Data{{/if}}</a>
             <a class="center btn btn-default hidden" download="data.csv" id="download-btn">Download</a>
-            <div id="save-dataset" class="hidden">
-                {{#if datasetName}}
-                    <p class="center" id="dataset-saved"><span class="glyphicon glyphicon-ok"></span> Dataset saved as "{{datasetName}}".</p>
-                    <p>Please refer to the User Profile tab for details.</p>
-                {{else}}
-                    <a class="center btn btn-default alternate" id="save-dataset-btn">Save Dataset ID</a>
-                {{/if}}
+            <div id="dataset-saved" class="hidden">
+                <p class="center"><span class="glyphicon glyphicon-ok"></span> Dataset saved as "<span id="dataset-name-txt"></span>".</p>
+                <p>Please refer to the User Profile tab for details.</p>
             </div>
+            <a class="center btn btn-default alternate" id="save-dataset-btn" class="hidden">Save Dataset ID</a>
         </div>
     </section>
 </div>

--- a/pic-sure-hpds-ui/src/main/webapp/picsureui/overrides/named-dataset.js
+++ b/pic-sure-hpds-ui/src/main/webapp/picsureui/overrides/named-dataset.js
@@ -1,0 +1,16 @@
+define([
+], function() {
+    return {
+		/*
+		 * This is a function that if defined replaces the normal render function
+		 * from outputPanel.
+		 */
+		renderOverride : undefined,
+
+		/*
+		* This function validates and saves the data from the form to the 
+		* /picsure/dataset/named api endpount
+		*/
+		onSave: undefined,
+    };
+});

--- a/pic-sure-hpds-ui/src/main/webapp/picsureui/styles.css
+++ b/pic-sure-hpds-ui/src/main/webapp/picsureui/styles.css
@@ -600,9 +600,6 @@ body {
 	margin-right: 100px;
 }
 
-.results-div {
-
-}
 .numeric-label {
 	padding-top: 10px;
 }
@@ -926,7 +923,7 @@ body {
     width: 125px;
 }
 
-.header-btn.active {
+.header-btn.active, .btn.alternate {
     color: white;
     background-color: var(--picsure-alt);
 }
@@ -1063,11 +1060,56 @@ input[type='checkbox'].categorical-filter-input {
  #resource-id-display {
     display: flex;
     flex-direction: column;
-    padding: 10px;
  }
+
+ #data-summary {
+    margin-bottom: 10px;
+ }
+ 
  #queryId-span {
     width: 276px;
  }
+
+ #query-id-container {
+    margin-top: 10px;
+ }
+
+ #query-status {
+    margin-top: 10px;
+    margin-bottom: 10px;
+ }
+
+ /* ==== Named Dataset Modal ==== */
+
+#save-dataset > #dataset-saved {
+    margin-top: 10px;
+}
+
+#dataset-query-info .row {
+    display: flex;
+    margin: 0px;
+}
+
+#dataset-query-info .row div {
+    padding: 5px 0;
+}
+
+#dataset-query-info .row div:first-child {
+    min-width: 30%;
+}
+
+#dataset-query-info .row div:last-child {
+    flex-grow: 2;
+}
+
+#dataset-name.error {
+    border: solid red 1px;
+}
+
+#named-dataset #buttons {
+    margin-top: 20px;
+}
+
 /* Genomic Modal */
 
 .no-padding {


### PR DESCRIPTION
- Adds a modal to the data export flow that allows a user to name and save their query/dataset id.
- Returns the user to the original modal on complete/cancel.