### PR TITLE
[ALS-2668] Remove virtual host configuration files

### DIFF
--- a/pic-sure-hpds-ui/Dockerfile
+++ b/pic-sure-hpds-ui/Dockerfile
@@ -2,9 +2,6 @@ FROM httpd:2.4.54-alpine
 
 RUN apk add --update openssl sed
 
-# Replace virtual host config file with ours
-COPY httpd/httpd-vhosts.conf ${HTTPD_PREFIX}/conf/extra/httpd-vhosts.conf
-
 # Enable virtual hosting config file
 RUN sed -i '/^#Include conf.extra.httpd-vhosts.conf/s/^#//' ${HTTPD_PREFIX}/conf/httpd.conf
 


### PR DESCRIPTION
[ALS-2668]  Virtual host configuration files have been removed from all relevant Dockerfiles for the PIC-SURE platform. This step simplifies the configuration by eliminating files that were previously copied into the Docker images. The necessary vhost files are added as part of our deployments.