### PR TITLE
[ALS-5567] Add dynamic login link to not_authorized template

### DIFF
--- a/pic-sure-hpds-ui/src/main/webapp/picsureui/psamaui/login/login.js
+++ b/pic-sure-hpds-ui/src/main/webapp/picsureui/psamaui/login/login.js
@@ -87,7 +87,7 @@ define(['common/session', 'common/searchParser', 'jquery', 'handlebars', 'login/
             else {
                 sessionStorage.clear();
                 localStorage.clear();
-                $('#main-content').html(HBS.compile(notAuthorizedTemplate)({helpLink:settings.helpLink}));
+                $('#main-content').html(HBS.compile(notAuthorizedTemplate)({helpLink:settings.helpLink, loginLink: (settings.loginLink ? settings.loginLink : "/psamaui/login/?redirection_url=/picsureui/")}));
             }
         }
     }

--- a/pic-sure-hpds-ui/src/main/webapp/picsureui/psamaui/login/not_authorized.hbs
+++ b/pic-sure-hpds-ui/src/main/webapp/picsureui/psamaui/login/not_authorized.hbs
@@ -2,5 +2,5 @@
     <h2>Not Authorized</h2>
     <p>Your user account is not yet authorized to use this system.</p>
     <p>Please contact the <a href="{{helpLink}}">administrator</a> if you believe this is an error.</p>
-    <p>If you believe you logged in using the wrong account, please <a href="/psamaui/login/?redirection_url=/picsureui/">Click Here</a> to try logging in again.</p>
+    <p>If you believe you logged in using the wrong account, please <a href="{{loginLink}}">Click Here</a> to try logging in again.</p>
 </div>


### PR DESCRIPTION
A dynamic login link has been added to the 'not_authorized' template in 'login.js'. This replaces the previously hard-coded URL, thereby improving the maintainability and configurability of the file.