### PR TITLE
[ALS-5580] Move close button color logic to router.js

### DIFF
--- a/pic-sure-hpds-ui/src/main/webapp/picsureui/common/router.js
+++ b/pic-sure-hpds-ui/src/main/webapp/picsureui/common/router.js
@@ -147,6 +147,13 @@ define([
                             let banner = bannerView.render();
                             // Render the banner at the top of the page.
                             $('#header').prepend(banner.$el);
+
+                            // Set the color of the close button based on the background color of the banner
+                            const backgroundColor = this.$('#banner').css('background-color');
+
+                            // Check if the background color is white or black. We cannot be sure if rgb, rgba, hex, or named color is used
+                            const isWhiteBackground = backgroundColor === 'rgb(255, 255, 255)' || backgroundColor === 'rgba(255, 255, 255, 0)' || backgroundColor === '#ffffff' || backgroundColor === 'white';
+                            this.$('#closeBannerBtn').css('color', isWhiteBackground ? 'black' : 'white');
                         }
                     }
                 }

--- a/pic-sure-hpds-ui/src/main/webapp/picsureui/header/banner.js
+++ b/pic-sure-hpds-ui/src/main/webapp/picsureui/header/banner.js
@@ -37,13 +37,6 @@ define(["jquery", "backbone", "handlebars", "text!header/banner.hbs"], function 
                 bannerCount: this.bannerCount
             }));
 
-            // Set the color of the close button based on the background color of the banner
-            const backgroundColor = this.$('#banner').css('background-color');
-
-            // Check if the background color is white or black. We cannot be sure if rgb, rgba, hex, or named color is used
-            const isWhiteBackground = backgroundColor === 'rgb(255, 255, 255)' || backgroundColor === 'rgba(255, 255, 255, 0)' || backgroundColor === '#ffffff' || backgroundColor === 'white';
-            this.$('#closeBannerBtn').css('color', isWhiteBackground ? 'black' : 'white');
-
             return this;
         },
     });


### PR DESCRIPTION
The code that sets the color of the close button in a banner, based on the banner's background color, has been moved from banner.js to router.js. The logic remains the same, but the change improves code organization by centralizing the manipulation of UI elements in the router file.