### PR TITLE
[ALS-5902] Update logout redirect URL in header.js

### DIFF
--- a/pic-sure-hpds-ui/src/main/webapp/picsureui/header/header.js
+++ b/pic-sure-hpds-ui/src/main/webapp/picsureui/header/header.js
@@ -103,7 +103,7 @@ define([
         },
         gotoLogin: function (event) {
             this.logout();
-            window.location = settings.logoutRedirect ?? "/psamaui/login" + window.location.search;
+            window.location = settings.loginRedirect ?? "/psamaui/login" + window.location.search;
         },
         headerClick: function(event) {
 		    if ($(event.target).data("href")) {

--- a/pic-sure-hpds-ui/src/main/webapp/picsureui/header/header.js
+++ b/pic-sure-hpds-ui/src/main/webapp/picsureui/header/header.js
@@ -103,7 +103,7 @@ define([
         },
         gotoLogin: function (event) {
             this.logout();
-            window.location = "/psamaui/login" + window.location.search;
+            window.location = settings.logoutRedirect ?? "/psamaui/login" + window.location.search;
         },
         headerClick: function(event) {
 		    if ($(event.target).data("href")) {


### PR DESCRIPTION
This update modifies the 'gotoLogin' function in header.js to use the logoutRedirect URL from settings, if it exists. If it doesn't exist, it will default to the "/psamaui/login" location. This change provides flexibility in setting custom logout redirect URLs.