### PR TITLE
[ALS-6103] Change Ajax request URL in login.js

### DIFF
--- a/pic-sure-hpds-ui/src/main/webapp/picsureui/psamaui/login/login.js
+++ b/pic-sure-hpds-ui/src/main/webapp/picsureui/psamaui/login/login.js
@@ -22,7 +22,7 @@ define(['common/session', 'common/searchParser', 'jquery', 'handlebars', 'login/
                 $('#main-content').html(overrides.waitingMessage);
             }
             $.ajax({
-                url: '/psama/authentication',
+                url: '/psama/authentication/auth0',
                 type: 'post',
                 data: JSON.stringify({
                     access_token : queryObject.access_token,


### PR DESCRIPTION
The URL for the Ajax request within login.js has been modified. It's updated from '/psama/authentication' to '/psama/authentication/auth0'.